### PR TITLE
Normalize formatted description before rendering post text

### DIFF
--- a/modules/formatting.py
+++ b/modules/formatting.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Post Formatting Module."""
+import unicodedata
 from datetime import timedelta
 from string import Formatter
 from typing import Any
@@ -51,6 +52,9 @@ def format_bluesky_post(
     # Fix issue with HTML2Text causing + to be rendered as \+
     formatted_description = formatted_description.replace(r"\+", "+")
 
+    # Normalize formatted description
+    formatted_description = unicodedata.normalize("NFKC", formatted_description)
+
     if len(formatted_description) > max_description_length:
         formatted_description = (
             f"{formatted_description[:max_description_length].strip()}...\n"
@@ -97,6 +101,9 @@ def format_mastodon_post(
 
     # Fix issue with HTML2Text causing + to be rendered as \+
     formatted_description = formatted_description.replace(r"\+", "+")
+
+    # Normalize formatted description
+    formatted_description = unicodedata.normalize("NFKC", formatted_description)
 
     if len(formatted_description) > max_description_length:
         formatted_description = (

--- a/podcast_bot.py
+++ b/podcast_bot.py
@@ -24,7 +24,7 @@ from modules.mastodon_client import MastodonClient
 from modules.podcast_feed import PodcastFeed
 from modules.settings import _DEFAULT_USER_AGENT, AppConfig, AppSettings, FeedSettings
 
-APP_VERSION: str = "1.1.0"
+APP_VERSION: str = "1.1.1"
 logger: logging.Logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Use `unicodedata.normalize` with `NKFC` to normalize characters, including non-breaking spaces represented by `\xa0`, before rendering out the post text for both Mastodon and Bluesky.