### PR TITLE
Bump Ruff and replace Black, Update Copyright Years, Correct argparse description

### DIFF
--- a/export_entries.py
+++ b/export_entries.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Export Podcast Feed Database Entries to a JSON File Script."""
+
 import json
 import sqlite3
 import sys

--- a/import_entries.py
+++ b/import_entries.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Import JSON Entries into a Podcast Feed Database Script."""
+
 import json
 import sqlite3
 import sys

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Linh Pham
+# Copyright (c) 2024-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #

--- a/modules/bluesky_client.py
+++ b/modules/bluesky_client.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2024 Linh Pham
+# Copyright (c) 2024-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Bluesky Client Module."""
+
 import sqlite3
 from pathlib import Path
 from sqlite3 import Connection, Cursor

--- a/modules/command.py
+++ b/modules/command.py
@@ -1,16 +1,20 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Command-Line Parsing Module."""
+
 from argparse import ArgumentParser, Namespace
 
 
 def parse() -> Namespace:
     """Parse command-line arguments, options and flags using ArgumentParser."""
     parser: ArgumentParser = ArgumentParser(
-        description="Fetch items from a podcast feed and publish new items to Mastodon."
+        description=(
+            "Fetch items from a podcast feed and publish new items "
+            "to Mastodon and/or Bluesky."
+        )
     )
     parser.add_argument(
         "-s",

--- a/modules/database.py
+++ b/modules/database.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Feed Database Module."""
+
 import datetime
 import sqlite3
 from pathlib import Path

--- a/modules/formatting.py
+++ b/modules/formatting.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Post Formatting Module."""
+
 import unicodedata
 from datetime import timedelta
 from string import Formatter

--- a/modules/mastodon_client.py
+++ b/modules/mastodon_client.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Mastodon Client Module."""
+
 from mastodon import Mastodon
 
 

--- a/modules/podcast_feed.py
+++ b/modules/podcast_feed.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=R1732
 """Podcast Feed Module."""
+
 import datetime
 from typing import Any
 

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import NamedTuple, Any
 
 _DEFAULT_USER_AGENT = (
-    "Mozilla/5.0 (X11; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0"
+    "Mozilla/5.0 (X11; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/134.0"
 )
 
 

--- a/podcast_bot.py
+++ b/podcast_bot.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024 Linh Pham
+# Copyright (c) 2022-2025 Linh Pham
 # podcast-bot is released under the terms of the MIT License
 # SPDX-License-Identifier: MIT
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Podcast Feed Bot."""
+
 import datetime
 import logging
 from argparse import Namespace
@@ -24,7 +25,7 @@ from modules.mastodon_client import MastodonClient
 from modules.podcast_feed import PodcastFeed
 from modules.settings import _DEFAULT_USER_AGENT, AppConfig, AppSettings, FeedSettings
 
-APP_VERSION: str = "1.1.2"
+APP_VERSION: str = "1.1.3"
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -135,7 +136,6 @@ def process_feeds(
 ):
     """Process podcast feeds and post new episodes."""
     for feed in feeds:
-
         logger.info("Podcast Name: %s", feed.name)
 
         if not feed.enabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-required-version = "24.10.0"
-target-version = ["py310", "py311", "py312"]
-line-length = 88
-
 [tool.pytest.ini_options]
 minversion = "8.0"
 filterwarnings = [
@@ -17,6 +12,7 @@ norecursedirs = [
 ]
 
 [tool.ruff]
+required-version = ">= 0.9.0"
 target-version = "py310"
 
 exclude = [
@@ -30,7 +26,7 @@ exclude = [
     ".venv",
 ]
 
-line-length = 88 # Must agree with Black
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 pytest==8.3.3
-black==24.10.0
-ruff==0.7.4
+ruff==0.9.4
 
 atproto==0.0.55
 Mastodon.py==1.8.1


### PR DESCRIPTION
* Bump Ruff from 0.7.4 to 0.9.4
* Remove Black from `requirements-dev.txt`
* Run Ruff formatting against Python files
* Update `pyproject.toml` to migrate linting and formatting from Black to Ruff
* Update copyright years
* Correct application Argument Parser description to include Bluesky
* Update default user agent string to the Firefox 134.0 on Linux