### PR TITLE
Add max title length feed setting for both Bluesky and Mastodon

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -63,6 +63,7 @@ Due to the experimental nature of the session token feature in the application, 
 | use_session_token | Enable the use of Bluesky session token to connect to Bluesky. (Default: `false`) |
 | api_url | The base API URL for Bluesky. (Default: `https://bsky.social`) |
 | template_file | Path for the Jinja2 template file that will be used to format the post. (Default: `templates/post-bluesky.txt.jinja`) |
+| max_title_length | Maximum length (in characters) of the podcast episode title to be included in the post. (Default: `100`) |
 | max_description_length | Maximum length (in characters) of the podcast episode description to be included in the post. (Default: `150`) |
 
 ### Mastodon Configuration Settings
@@ -90,6 +91,7 @@ If you do not want the application to publish to Mastodon, you will need to set 
 | client_secret | Mastodon API client secret used for authentication. Not required when using OAuth authentication. |
 | access_token | Mastodon API access token used for authentiication. Not required when using OAuth authentication. |
 | template_file | Path for the Jinja2 template file that will be used to format the post. (Default: `templates/post-mastodon.txt.jinja`) |
+| max_title_length | Maximum length (in characters) of the podcast episode title to be included in the post. (Default: `100`) |
 | max_description_length | Maximum length (in characters) of the podcast episode description to be included in the post. (Default: `275`) |
 
 ## Running the Application

--- a/modules/formatting.py
+++ b/modules/formatting.py
@@ -25,6 +25,7 @@ def unsmart_quotes(text: str) -> str:
 def format_bluesky_post(
     episode: dict[str, Any],
     podcast_name: str,
+    max_title_length: int,
     max_description_length: int,
     template_path: str,
     template_file: str,
@@ -47,6 +48,9 @@ def format_bluesky_post(
 
     # Replace "smart" quotes with regular quotes
     title: str = unsmart_quotes(text=episode["title"])
+    if len(title) > max_title_length:
+        title = f"{title[:max_title_length].strip()}..."
+
     description: str = unsmart_quotes(text=episode["description"])
     formatted_description: str = formatter.handle(description)
 
@@ -75,6 +79,7 @@ def format_bluesky_post(
 def format_mastodon_post(
     episode: dict[str, Any],
     podcast_name: str,
+    max_title_length: int,
     max_description_length: int,
     template_path: str,
     template_file: str,
@@ -97,6 +102,9 @@ def format_mastodon_post(
 
     # Replace "smart" quotes with regular quotes
     title: str = unsmart_quotes(text=episode["title"])
+    if len(title) > max_title_length:
+        title = f"{title[:max_title_length].strip()}..."
+
     description: str = unsmart_quotes(text=episode["description"])
     formatted_description: str = formatter.handle(description)
 

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -33,6 +33,8 @@ class BlueskySettings(NamedTuple):
     "Path to the directory containing the Jinja template file."
     template_file: str
     "Name of the Jinja template file."
+    max_title_length: int
+    "Maximum podcast title length."
     max_description_length: int
     "Maximum podcast episode description length."
 
@@ -56,6 +58,8 @@ class MastodonSettings(NamedTuple):
     "Path to the directory containing the Jinja template file."
     template_file: str
     "Name of the Jinja template file."
+    max_title_length: int
+    "Maximum podcast title length."
     max_description_length: int
     "Maximum podcast episode description length."
 
@@ -131,6 +135,7 @@ class AppConfig:
             template_file=bluesky_settings.get(
                 "template_file", "post-bluesky.txt.jinja"
             ).strip(),
+            max_title_length=int(bluesky_settings.get("max_title_length", 100)),
             max_description_length=int(
                 bluesky_settings.get("max_description_length", 150)
             ),
@@ -176,6 +181,7 @@ class AppConfig:
             template_file=mastodon_settings.get(
                 "template_file", "post-mastodon.txt.jinja"
             ).strip(),
+            max_title_length=int(mastodon_settings.get("max_title_length", 100)),
             max_description_length=int(
                 mastodon_settings.get("max_description_length", 275)
             ),

--- a/podcast_bot.py
+++ b/podcast_bot.py
@@ -25,7 +25,7 @@ from modules.mastodon_client import MastodonClient
 from modules.podcast_feed import PodcastFeed
 from modules.settings import _DEFAULT_USER_AGENT, AppConfig, AppSettings, FeedSettings
 
-APP_VERSION: str = "1.1.4"
+APP_VERSION: str = "1.2.0"
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -239,10 +239,14 @@ def process_feeds(
                     post_text: str = format_bluesky_post(
                         podcast_name=feed.name,
                         episode=episode,
+                        max_title_length=feed.bluesky_settings.max_title_length,
                         max_description_length=feed.bluesky_settings.max_description_length,
                         template_path=feed.bluesky_settings.template_path,
                         template_file=feed.bluesky_settings.template_file,
                     )
+
+                    if dry_run:
+                        logger.debug("Bluesky Post Text: %s", post_text)
 
                     if not dry_run:
                         logger.info("Bluesky: Posting %s", post_text)
@@ -254,10 +258,14 @@ def process_feeds(
                     post_text: str = format_mastodon_post(
                         podcast_name=feed.name,
                         episode=episode,
+                        max_title_length=feed.mastodon_settings.max_title_length,
                         max_description_length=feed.mastodon_settings.max_description_length,
                         template_path=feed.mastodon_settings.template_path,
                         template_file=feed.mastodon_settings.template_file,
                     )
+
+                    if dry_run:
+                        logger.debug("Mastodon Post Text: %s", post_text)
 
                     if not dry_run:
                         logger.info("Mastodon: Posting %s", post_text)

--- a/settings.dist.json
+++ b/settings.dist.json
@@ -21,6 +21,7 @@
                 "api_url": "https://bsky.social",
                 "template_path": "templates",
                 "template_file": "post-bluesky.txt.jinja",
+                "max_title_length": 100,
                 "max_description_length": 150
             },
             "mastodon_settings": {
@@ -32,6 +33,7 @@
                 "access_token": "",
                 "template_path": "templates",
                 "template_file": "post-mastodon.txt.jinja",
+                "max_title_length": 100,
                 "max_description_length": 275
             }
         }


### PR DESCRIPTION
Add `max_title_length` to both `bluesky_settings` and `mastodon_settings` for each feed with a default value of `100`.

As with `max_description_length`, the `max_title_length` will cause the podcast episode title to be truncated to 100 characters, then appends the string with `...`.